### PR TITLE
fix memory crash in prob_any_missing

### DIFF
--- a/src/prob_any_missing.cpp
+++ b/src/prob_any_missing.cpp
@@ -69,6 +69,12 @@ std::vector<float> probAnyMissingFunctor::vectorized(
     const std::size_t totalEvents = eventProbs.size();
 
     std::vector<float> probVec(maxNumEvents - minNumEvents + 1, 0.0);
+    
+    if (maxNumEvents < totalEvents) {
+        std::fill_n(probVec.begin(), maxNumEvents - minNumEvents + 1, 1.0);
+        return probVec;
+    }
+
     std::fill_n(probVec.begin(), totalEvents - 1, 1.0);
 
     //      Calculate via inclusion-exclusion principle


### PR DESCRIPTION
The code fix addresses a memory crash issue in the `prob_any_missing` function. The fix includes adding a condition to check if `maxNumEvents` is less than `totalEvents`. If true, it fills the `probVec` vector with 1.0 and returns it. This prevents the memory crash and ensures proper execution of the function.